### PR TITLE
Potential fix for code scanning alert no. 227: Disabled Spring CSRF protection

### DIFF
--- a/services/product-service/src/main/java/com/lloms/productservice/config/SecurityConfig.java
+++ b/services/product-service/src/main/java/com/lloms/productservice/config/SecurityConfig.java
@@ -35,10 +35,9 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                // Disable CSRF for stateless JWT API (JWT tokens are not vulnerable to CSRF)
-                // CSRF protection is not needed for stateless APIs using JWT authentication
-                // Additional security: JWT tokens are sent in Authorization header, not cookies
-                .csrf(AbstractHttpConfigurer::disable)
+                // CSRF protection is enabled by default, providing defense-in-depth for browser clients
+
+
 
                 // Enable CORS
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))


### PR DESCRIPTION
Potential fix for [https://github.com/dihaxn/Pos-System/security/code-scanning/227](https://github.com/dihaxn/Pos-System/security/code-scanning/227)

To fix this CSRF vulnerability, re-enable CSRF protection by removing or modifying the `.csrf(AbstractHttpConfigurer::disable)` statement. If your application exclusively uses stateless JWT authentication with Authorization headers (never cookies), you may *still* prefer to keep CSRF protection enabled for defense-in-depth (and to prevent future misconfiguration). You can configure CSRF as follows:
1. Remove the call to `AbstractHttpConfigurer::disable` on `.csrf()`.
2. Optionally, restrict CSRF protection using the `.csrf().ignoringRequestMatchers(...)` method if your API is strictly stateless and only the documented endpoints require CSRF bypass (for example, OpenAPI endpoints or static docs), but **don't** disable it globally.
3. Given the current code, the best and most correct fix is to simply **remove the line** that disables CSRF, allowing Spring Security's default (CSRF enabled) for all endpoints.

No new methods, definitions, or imports are needed: simply delete or comment out `.csrf(AbstractHttpConfigurer::disable)` (line 41).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
